### PR TITLE
Feature/8 Replace git2 with raw git command for collecting ignored paths

### DIFF
--- a/src/lib.rs
+++ b/src/lib.rs
@@ -16,7 +16,8 @@
 // along with ignore-rm.  If not, see <https://www.gnu.org/licenses/>.
 
 use dialoguer::{Confirm, FuzzySelect, Input, theme::ColorfulTheme};
-use git2::{Repository, Status, StatusOptions};
+use git2::Repository;
+use std::process::Command;
 use std::{
     fs, io,
     path::{Path, PathBuf},
@@ -35,6 +36,8 @@ pub enum PickerError {
     DeleteError(PathBuf, #[source] std::io::Error),
     #[error("failed to StripPrefixError")]
     StripPrefixError(#[from] std::path::StripPrefixError),
+    #[error("path is not valid UTF-8")]
+    NonUtf8Path,
 }
 
 /// Opens a folder picker starting at `start` and returns the selected relative path.
@@ -203,63 +206,42 @@ pub fn wait_for_enter() -> Result<(), PickerError> {
     Ok(())
 }
 
-pub fn collect_ignored_paths<'a>(
-    repo: &Repository,
-    path_to_delete: &Path,
-    out: &'a mut Vec<PathBuf>,
-) -> Result<&'a Vec<PathBuf>, PickerError> {
-    // Detect submodules
-    for sub in repo.submodules()? {
-        if let Ok(sm_repo) = sub.open() {
-            // If the path_to_delete is inside a submodule:
-            if path_to_delete.starts_with(&sub.path()) {
-                println!(
-                    "Path to delete {} is inside submodule at {}",
-                    path_to_delete.display(),
-                    sub.path().display()
-                );
-                // Strip the submodule prefix to get the relative path:
-                let rel = path_to_delete
-                    .strip_prefix(sub.path())
-                    .expect("path_to_delete always starts with sub.path()");
-                // Recurse into that submodule with the relative path.
-                return collect_ignored_paths(&sm_repo, rel, out);
-            }
-            // If the submodule itself lies within the path_to_delete:
-            if sub.path().starts_with(&path_to_delete) {
-                println!(
-                    "Submodule at {} lies within path to delete {}",
-                    sub.path().display(),
-                    path_to_delete.display()
-                );
-                // Collect all of its ignored files.
-                collect_ignored_paths(&sm_repo, Path::new(""), out)?;
-            }
-        }
+pub fn collect_ignored_paths(path: &Path) -> Result<Vec<PathBuf>, PickerError> {
+    // If the path is empty (""), default to "."
+    let path = if path.as_os_str().is_empty() {
+        std::path::Path::new(".")
+    } else {
+        path
+    };
+
+    // Convert &Path -> &str, but catch non‐UTF8
+    let path_arg = path.to_str().ok_or(PickerError::NonUtf8Path)?;
+
+    let output = Command::new("git")
+        .args(&[
+            "ls-files",
+            "--others",
+            "--ignored",
+            "--exclude-standard",
+            "--directory",
+            "--",
+            path_arg,
+        ])
+        .output()?;
+
+    if !output.status.success() {
+        // If Git wrote UTF-8 to stderr, use it; otherwise, fall back on raw bytes:
+        let stderr_text = String::from_utf8_lossy(&output.stderr).to_string();
+        return Err(PickerError::Io(std::io::Error::new(
+            std::io::ErrorKind::Other,
+            format!("git command failed: {}", stderr_text),
+        )));
     }
 
-    // Configure StatusOptions to include ignored entries and recurse into untracked directories
-    println!(
-        "Obtaining ignored files from {}",
-        repo.working_dir().join(path_to_delete).display()
-    );
-    let mut opts = StatusOptions::new();
-    opts.include_ignored(true)
-        .recurse_ignored_dirs(true)
-        .recurse_untracked_dirs(true);
+    // Git’s stdout is newline‐separated paths (relative to CWD). Convert each to PathBuf.
+    let stdout = String::from_utf8_lossy(&output.stdout);
+    let list: Vec<PathBuf> = stdout.lines().map(PathBuf::from).collect();
 
-    if !path_to_delete.to_str().unwrap_or("").is_empty() {
-        opts.disable_pathspec_match(true).pathspec(path_to_delete);
-    }
-
-    let statuses = repo.statuses(Some(&mut opts))?;
-    for entry in statuses.iter() {
-        if entry.status().contains(Status::IGNORED) {
-            if let Some(path) = entry.path() {
-                out.push(repo.working_dir().join(path));
-            }
-        }
-    }
-
-    Ok(out)
+    println!("{:?}", list);
+    Ok(list)
 }

--- a/src/lib.rs
+++ b/src/lib.rs
@@ -206,18 +206,64 @@ pub fn wait_for_enter() -> Result<(), PickerError> {
     Ok(())
 }
 
-pub fn collect_ignored_paths(path: &Path) -> Result<Vec<PathBuf>, PickerError> {
+/// Returns a Vec<PathBuf> containing each submodule’s path (relative to the repository root, as stored in .gitmodules)
+fn submodule_paths(repo_path: &Path) -> Result<Vec<PathBuf>, PickerError> {
+    // Open the repository at `repo_path`
+    let repo = Repository::open(repo_path)?;
+    // `repo.submodules()` returns a Vec<Submodule>
+    let subs = repo.submodules()?;
+    // Cada path de submódulo es relativo a la raíz del repo, así que lo unimos con repo_path
+    let paths = subs
+        .into_iter()
+        .map(|sm| repo_path.join(sm.path()))
+        .collect();
+    Ok(paths)
+}
+
+// Collects all ignored paths (files and directories) in a Git repository and its submodules.
+// - repo_path: Path to the root of the repository.
+// - rel_path: Relative path within the repository to search for ignored files.
+pub fn collect_ignored_paths(
+    repo_path: &Path,
+    rel_path: &Path,
+) -> Result<Vec<PathBuf>, PickerError> {
     // If the path is empty (""), default to "."
-    let path = if path.as_os_str().is_empty() {
+    let rel_path = if rel_path.as_os_str().is_empty() {
         std::path::Path::new(".")
     } else {
-        path
+        rel_path
     };
 
-    // Convert &Path -> &str, but catch non‐UTF8
-    let path_arg = path.to_str().ok_or(PickerError::NonUtf8Path)?;
+    let mut ignored_paths = Vec::new();
 
+    // Get submodule paths (if any)
+    let sub_paths = match submodule_paths(repo_path) {
+        Ok(paths) => paths,
+        Err(PickerError::Git2(ref e)) if e.code() == git2::ErrorCode::NotFound => {
+            // Submodule is not initialized
+            Vec::new()
+        }
+        Err(e) => return Err(e),
+    };
+
+    // Recursively collect ignored paths from submodules
+    for sub_path in &sub_paths {
+        match collect_ignored_paths(&sub_path, Path::new(".")) {
+            Ok(submodule_ignored) => ignored_paths.extend(submodule_ignored),
+            Err(PickerError::Git2(ref e)) if e.code() == git2::ErrorCode::NotFound => {
+                // Submodule not initialized, skip
+                continue;
+            }
+            Err(e) => return Err(e),
+        }
+    }
+
+    // Convert rel_path to &str, error if not valid UTF-8
+    let path_arg = rel_path.to_str().ok_or(PickerError::NonUtf8Path)?;
+
+    // Run the git command to list ignored files and directories
     let output = Command::new("git")
+        .current_dir(repo_path)
         .args(&[
             "ls-files",
             "--others",
@@ -230,7 +276,6 @@ pub fn collect_ignored_paths(path: &Path) -> Result<Vec<PathBuf>, PickerError> {
         .output()?;
 
     if !output.status.success() {
-        // If Git wrote UTF-8 to stderr, use it; otherwise, fall back on raw bytes:
         let stderr_text = String::from_utf8_lossy(&output.stderr).to_string();
         return Err(PickerError::Io(std::io::Error::new(
             std::io::ErrorKind::Other,
@@ -238,10 +283,12 @@ pub fn collect_ignored_paths(path: &Path) -> Result<Vec<PathBuf>, PickerError> {
         )));
     }
 
-    // Git’s stdout is newline‐separated paths (relative to CWD). Convert each to PathBuf.
+    // Parse the output: each line is a path relative to repo_path
     let stdout = String::from_utf8_lossy(&output.stdout);
-    let list: Vec<PathBuf> = stdout.lines().map(PathBuf::from).collect();
+    let list: Vec<PathBuf> = stdout.lines().map(|line| repo_path.join(line)).collect();
 
-    println!("{:?}", list);
-    Ok(list)
+    // Add found paths to the result
+    ignored_paths.extend(list);
+
+    Ok(ignored_paths)
 }

--- a/src/main.rs
+++ b/src/main.rs
@@ -19,7 +19,7 @@ use ignore_rm::{
     PickerError, RepositoryExt, collect_ignored_paths, confirm_delete_files, delete_paths,
     discover_topmost, pick_folder, wait_for_enter,
 };
-use std::{env, path::PathBuf};
+use std::env;
 
 fn main() -> Result<(), PickerError> {
     // Get the current directory
@@ -31,19 +31,18 @@ fn main() -> Result<(), PickerError> {
     println!("Path to delete temporary files: {:?}", selected_folder);
 
     // Obtain all the ignored paths from that path
-    let mut ignored_paths_tmp: Vec<PathBuf> = Vec::new();
-    let ignored_paths = collect_ignored_paths(&repo, &selected_folder, &mut ignored_paths_tmp)?;
+    let ignored_paths = collect_ignored_paths(&selected_folder)?;
 
     if !ignored_paths.is_empty() {
         // Print a header message before listing files
         println!("Files to be deleted:");
-        for path in ignored_paths {
+        for path in &ignored_paths {
             println!("   {}", path.display());
         }
 
         // Confirm deletion by user
         if confirm_delete_files() {
-            delete_paths(&repo.working_dir(), ignored_paths_tmp)?;
+            delete_paths(&repo.working_dir(), ignored_paths)?;
             println!("Deletion completed.");
         } else {
             println!("Aborted; no files were deleted.");

--- a/src/main.rs
+++ b/src/main.rs
@@ -31,7 +31,7 @@ fn main() -> Result<(), PickerError> {
     println!("Path to delete temporary files: {:?}", selected_folder);
 
     // Obtain all the ignored paths from that path
-    let ignored_paths = collect_ignored_paths(&selected_folder)?;
+    let ignored_paths = collect_ignored_paths(&repo.working_dir(), &selected_folder)?;
 
     if !ignored_paths.is_empty() {
         // Print a header message before listing files


### PR DESCRIPTION
# References
  - #8

# Changelog
  - Replace git2 with raw git command for collecting ignored paths while also supporting submodules.